### PR TITLE
Enable multi-arch builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v3
       
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
       - name: docker-metadata
         id: docker-metadata
         uses: docker/metadata-action@v4
@@ -53,3 +59,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.docker-metadata.outputs.tags }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
This sets up the container builds to do multi-architecture builds.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
