### PR TITLE
Remove `linux/arm/v7` from platforms to build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.docker-metadata.outputs.tags }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This is not supported by the chainguard image we use as a base.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
